### PR TITLE
Moved the call to unselect_all() when inserting symbols.

### DIFF
--- a/src/actions.c
+++ b/src/actions.c
@@ -991,6 +991,7 @@ int place_symbol(int pos, const char *symbol_name, double x, double y, short rot
 /*  if symbol_name is a valid string load specified cell and */
 /*  use the given params, otherwise query user */
 {
+ unselect_all();
  int i,j,n;
  char name[PATH_MAX];
  char *type;

--- a/src/callback.c
+++ b/src/callback.c
@@ -122,7 +122,6 @@ static void start_place_symbol(double mx, double my)
       tclvareval("set INITIALINSTDIR [file dirname {",
            abs_sym_path(xctx->inst[xctx->sel_array[0].n].name, ""), "}]", NULL);
     } 
-    unselect_all();
     xctx->mx_double_save = xctx->mousex_snap;
     xctx->my_double_save = xctx->mousey_snap;
     if(place_symbol(-1,NULL,xctx->mousex_snap, xctx->mousey_snap, 0, 0, NULL, 4, 1, 1/* to_push_undo */) ) {


### PR DESCRIPTION
I was having the following issue:

If I have a symbol selected on my schematic, lets call it symbol "A". Then I try to insert a new symbol, Call it "B". They both become selected and they both move. If I then cancel the operation. Symbol "A" deletes.

I noticed you had a call to `unselect_all()` but it wasn't being called if you inserted a symbol from the menu or the toolbar. 

I moved the call from `start_place_symbol` to `place_symbol` and it all seems to be working well.