### PR TITLE
Remove cursor config in schematic window

### DIFF
--- a/src/callback.c
+++ b/src/callback.c
@@ -49,7 +49,7 @@ static int waves_selected(int event, KeySym key, int state, int button)
     }
   }
   if(!is_inside) {
-    tclvareval(xctx->top_path, ".drw configure -cursor arrow" , NULL);
+    //tclvareval(xctx->top_path, ".drw configure -cursor arrow" , NULL);
     if(xctx->graph_flags & 64) {
       tcleval("graph_show_measure stop");
     }


### PR DESCRIPTION
The cursor is changed to "arrow" in the schematic window

```c
tclvareval(xctx->top_path, ".drw configure -cursor arrow" , NULL);
```
As shown in the screenshot below, the "arrow" cursor points toward the top right, instead of the usual top left.

<img src="https://user-images.githubusercontent.com/121698703/210122240-6684305e-5577-46ce-858d-f40e57343772.png" width="300">

With this line removed, the cursor configuration is not changed and hence the cursor does not change direction.

```c
//tclvareval(xctx->top_path, ".drw configure -cursor arrow" , NULL);
```

<img src="https://user-images.githubusercontent.com/121698703/210122254-5b448d42-ef9b-49e4-9987-d3c12c6658b8.png" width="300">
