### PR TITLE
propose to change Configure simulators and tools button default behavior in src/xschem.tcl

### DIFF
--- a/src/xschem.tcl
+++ b/src/xschem.tcl
@@ -1453,23 +1453,25 @@ Foreground (Fg) checkbutton tells xschem to wait for child process to finish.
 Status checkbutton tells xschem to report a status dialog (stdout, stderr,
 exit status) when process finishes.
 Any changes made in the command or tool name entries will be saved in 
-~/.xschem/simrc when 'Save Configuration to file' button is pressed.
-If 'Accept and Close' is pressed then the changes are kept in memory and dialog
-is closed without writing to a file, if xschem is restarted changes will be lost.
+~/.xschem/simrc when 'OK and Close' button or 'Apply Not Close' button is pressed.
 If no ~/.xschem/simrc is present then a minimal default setup is presented.
 To reset to default use the corresponding button or just delete the ~/.xschem/simrc
 file manually.
     } ro
   }
-  button .sim.bottom.ok  -text {Save Configuration to file} -command "simconf_saveconf $scrollframe"
+  #If 'Accept and Close' is pressed then the changes are kept in memory and dialog
+  #is closed without writing to a file, if xschem is restarted changes will be lost.
+  #button .sim.bottom.ok  -text {Save Configuration to file} -command "simconf_saveconf $scrollframe"
+  button .sim.bottom.ok  -text {Apply (Not Close)} -command "simconf_saveconf $scrollframe"
   button .sim.bottom.reset -text {Reset to default} -command {
     simconf_reset
   }
-  button .sim.bottom.close -text {Accept and Close} -command {
+  button .sim.bottom.close -text {OK and Close} -command "
+    simconf_saveconf $scrollframe 
     set_sim_defaults
     destroy .sim
     xschem set semaphore [expr {[xschem get semaphore] -1}]
-  }
+  "
   wm protocol .sim WM_DELETE_WINDOW {
     set_sim_defaults 
     destroy .sim


### PR DESCRIPTION
Reason for the proposal: It feels really strange to me when Accept and Close button doesn't save the setup into file by default. It means if I don't click the save configure to file button before 'Accept and Close', all the changes I made will lost. So I add the save to file feature into the 'Accept and Close button' and also change the text description.

I will keep this open for a few days, feel free to ignore/dislike it. I can pull it back.

1. change 'Accept and close' button to save changes into file and then close. 
          a. remove the original behavior to keep the change in the memory and lose it if the dialog is closed 
          b. change the button name slightly from 'Accept and close' to 'OK and Close'
2. change button name from 'Save Configuration to file' to 'Apply (Not Close)'



eventually, the button name can be simplified to 'OK' and 'Apply'

![image](https://github.com/StefanSchippers/xschem/assets/10713939/b5d6e606-7887-4e3d-9ea7-6194b0a96e55)
 
![image](https://github.com/StefanSchippers/xschem/assets/10713939/2767a570-ceb6-427c-9e0c-8b31b196dbe7)
![image](https://github.com/StefanSchippers/xschem/assets/10713939/4091b817-4a1a-45bd-947e-68e6236388ef)
