### PR TITLE
Add support for 'd' and CTRL-'d' for deselection

### DIFF
--- a/src/callback.c
+++ b/src/callback.c
@@ -3980,14 +3980,14 @@ int rstate; /* (reduced state, without ShiftMask) */
     draw();
     break;
    }
-   if(key=='D' && rstate == 0)                     /* delete files */
+   if(key=='d' && rstate == ControlMask)                     /* delete files */
    {
     if(xctx->semaphore >= 2) break;
     delete_files();
     break;
    }
 
-   if( key == 'd' && rstate == ControlMask){
+   if( key == 'D' && rstate == 0){
      if(infix_interface) {
       xctx->ui_state = WAIT_DESELECT_END | STARTDESELECT;
       xctx->last_command = 0;

--- a/src/callback.c
+++ b/src/callback.c
@@ -3988,7 +3988,17 @@ int rstate; /* (reduced state, without ShiftMask) */
    }
 
    if( key == 'd' && rstate == ControlMask){
-     xctx->ui_state = WAIT_DESELECT_CLICK | STARTDESELECT;
+     if(infix_interface) {
+      xctx->ui_state = WAIT_DESELECT_END | STARTDESELECT;
+      xctx->last_command = 0;
+      xctx->mx_save = mx; xctx->my_save = my;
+      xctx->mx_double_save=xctx->mousex_snap;
+      xctx->my_double_save=xctx->mousey_snap;
+      select_rect(enable_stretch, START,0);
+      rebuild_selected_array(); /* sets or clears xctx->ui_state SELECTION flag */
+     } else {
+      xctx->ui_state = WAIT_DESELECT_CLICK | STARTDESELECT;
+     }
      break;
    }
 

--- a/src/xschem.h
+++ b/src/xschem.h
@@ -229,7 +229,10 @@ extern char win_temp_dir[PATH_MAX];
 #define START_SYMPIN 16384U
 #define GRAPHPAN 32768U     /* bit 15 */
 #define MENUSTART 65536U    /* bit 16 */
-#define GRABSCREEN 131072   /* bit 17 */
+#define GRABSCREEN 131072U   /* bit 17 */
+#define WAIT_DESELECT_CLICK 262144U /* bit 18 */
+#define STARTDESELECT 524288U   /* bit 19 */
+#define WAIT_DESELECT_END 1048576U   /* bit 20 */
 
 #define SELECTED 1U         /*  used in the .sel field for selected objs. */
 #define SELECTED1 2U        /*  first point selected... */


### PR DESCRIPTION
Addresses https://github.com/StefanSchippers/xschem/issues/290

'd' - press 'd' and then you can click once on a selected object (wire, instance, etc) to deselect it. Supports infix_interface
CTRL-'d' (because SHIFT-'d' is already used for delete-files) - now you can enter two clicks to input a deselection rectangle. No infix support - that is, mouse pointer at CTRL-'d' being pressed will not be used even if infix_interface =1. But, this should be minor.

I think this is more user-friendly than ALT + mouse (or WIN+ mouse) because users who care about productivity will use ALT + mouse for window manipulation.