### PR TITLE
spectre_format for more symbols.

### DIFF
--- a/xschem_library/devices/connect.sym
+++ b/xschem_library/devices/connect.sym
@@ -22,6 +22,9 @@ v {xschem version=3.4.6 file_version=1.2
 G {}
 K {type=resistor
 format="@name @pinlist 0.01 m=@m"
+spectre_format="@name ( @pinlist ) resistor r=0.01 $mfactor=@m"
+spectre_device_model="load \\"resistor.osdi\\"
+model resistor resistor"
 template="name=R1 m=1"}
 V {}
 S {}

--- a/xschem_library/devices/led.sym
+++ b/xschem_library/devices/led.sym
@@ -22,6 +22,7 @@ v {xschem version=3.4.4 file_version=1.2
 G {}
 K {type=diode
 format="@spiceprefix@name @pinlist @model"
+spectre_format="@spiceprefix@name ( @pinlist ) @model"
 
 tedax_format="footprint @name @footprint
 value @name @value

--- a/xschem_library/devices/parax_cap.sym
+++ b/xschem_library/devices/parax_cap.sym
@@ -22,6 +22,9 @@ v {xschem version=3.4.5 file_version=1.2
 G {}
 K {type=parax_cap
 format="@name @pinlist @gnd @value m=@m"
+spectre_format="@name ( @pinlist @gnd ) capacitor c=@value $mfactor=@m"
+spectre_device_model="load \\"capacitor.osdi\\"
+model capacitor capacitor"
 verilog_ignore=true
 template="name=C1 gnd=0 value=4f m=1"}
 V {}

--- a/xschem_library/devices/res3.sym
+++ b/xschem_library/devices/res3.sym
@@ -23,6 +23,7 @@ G {}
 K {type=poly_resistor
 comment="User must provide a 3-terminal subcircuit for this device"
 format="@spiceprefix@name @pinlist @model R=@R W=@W L=@L m=@m"
+spectre_format="@spiceprefix@name ( @pinlist ) @model R=@R W=@W L=@L m=@m"
 template="name=R1
 R=1
 W=1

--- a/xschem_library/devices/res_noisy.sym
+++ b/xschem_library/devices/res_noisy.sym
@@ -32,6 +32,9 @@ format="tcleval([
     return \{@name @pinlist @value m=@m \}
   \}
 ])"
+spectre_format="@name ( @pinlist ) resistor r=@value has_noise=@noisy $mfactor=@m"
+spectre_device_model="load \\"resistor.osdi\\"
+model resistor resistor"
 verilog_format="tran @name (@@P\\\\, @@M\\\\);"
 
 template="name=R1

--- a/xschem_library/devices/rgb_led.sym
+++ b/xschem_library/devices/rgb_led.sym
@@ -21,6 +21,7 @@ v {xschem version=3.4.4 file_version=1.2
 }
 G {type=diode
 format="@spiceprefix@name @pinlist @model"
+spectre_format="@spiceprefix@name ( @pinlist ) @model"
 tedax_format="footprint @name @footprint
 value @name @value
 device @name @device


### PR DESCRIPTION
I added some more spectre_format attributes in the xschem device library. Please review and merge. 

I also have a suggestion/question. If during netlisting a symbol does not have a format= attribute (in my case spectre_format=) then the netlister should at least print a warning instead of silently creating a netlist with missing critical elements. If such a feature would be annoying, then at least there should be a way to optionally enable it. 