### PR TITLE
Fuzzy subsequence search in the file-load and file_chooser dialogs

### DIFF
--- a/src/xschem.tcl
+++ b/src/xschem.tcl
@@ -5839,6 +5839,77 @@ proc file_chooser_delete {} {
 }
 
 #### maxdepth: how many levels to descend for each $paths directory (-1: no limit)
+proc fuzzy_chooser_inline {q} {
+  global file_chooser new_file_browser_depth new_file_browser_ext pathlist
+  if {$q eq {}} {
+    set file_chooser(files) {}
+    set file_chooser(fullpathlist) {}
+    set file_chooser(nitems) 0
+    .ins.center.leftdir.l selection clear 0 end
+    file_chooser_dirlist
+    return
+  }
+  set nfbe $new_file_browser_ext
+  if {[catch {regexp $nfbe {12345}}]} { set nfbe {} }
+  set allfiles [match_file {} {} $new_file_browser_depth 1]
+  set scored {}
+  foreach f $allfiles {
+    if {$nfbe ne {}} {
+      set ok 0
+      catch {set ok [regexp $nfbe $f]}
+      if {!$ok} continue
+    }
+    set sc [fuzzy_subseq_score $q $f]
+    if {$sc >= 0} { lappend scored [list $sc $f] }
+  }
+  set sorted [lsort -decreasing -integer -index 0 $scored]
+  set hits {}
+  set n 0
+  foreach pair $sorted {
+    if {$n >= 500} break
+    lappend hits [lindex $pair 1]
+    incr n
+  }
+  set seen_dir [dict create]
+  set new_dirs {}
+  foreach f $hits {
+    set d [file dirname $f]
+    if {![dict exists $seen_dir $d]} {
+      dict set seen_dir $d 1
+      lappend new_dirs $d
+    }
+  }
+  set new_tails {}
+  foreach d $new_dirs {
+    set t {}
+    foreach p $pathlist {
+      set pp [file dirname $p]/
+      if {[string first $pp $d] == 0} {
+        set t [string range $d [string length $pp] end]
+        break
+      }
+    }
+    if {$t eq {}} { set t [file tail $d] }
+    lappend new_tails $t
+  }
+  set file_chooser(dirs) $new_dirs
+  set file_chooser(dirtails) $new_tails
+  set file_chooser(files) $hits
+  set file_chooser(fullpathlist) $hits
+  set file_chooser(nitems) [llength $hits]
+  global dark_gui_colorscheme
+  if {$dark_gui_colorscheme} { set col cyan } else { set col blue }
+  set i 0
+  foreach p $file_chooser(dirs) {
+    if {[lsearch -exact $pathlist $p] != -1} {
+      .ins.center.leftdir.l itemconfigure $i -foreground $col -selectforeground $col
+    } else {
+      .ins.center.leftdir.l itemconfigure $i -foreground black -selectforeground black
+    }
+    incr i
+  }
+}
+
 proc file_chooser {} {
   global file_chooser new_file_browser_ext new_file_browser_depth USER_CONF_DIR
   set file_chooser(action) load
@@ -5963,6 +6034,14 @@ proc file_chooser {} {
   entry .ins.top3.ext_e -width 30 -takefocus 0  -state normal -textvariable new_file_browser_ext
   balloon .ins.top3.ext_e "Show only files matching the\nextension regular expression"
 
+  label .ins.top3.fzf_l -text {  Fuzzy:}
+  entry .ins.top3.fzf_e -width 25 -highlightcolor red -highlightthickness 2 \
+    -highlightbackground [option get . background {}]
+  balloon .ins.top3.fzf_e "Subsequence-match across all library paths.\nLeft pane shows dirs with hits; middle pane shows full paths."
+  bind .ins.top3.fzf_e <KeyRelease> {
+    fuzzy_chooser_inline [.ins.top3.fzf_e get]
+  }
+
   button .ins.top4.select_current -takefocus 0 -text {Select current} -command {
     set file_chooser(regex) {}
     file_chooser_select [xschem get schname]
@@ -6033,6 +6112,10 @@ proc file_chooser {} {
   }
 
   bind .ins.top3.pat_e <KeyRelease> {
+    if {[winfo exists .ins.top3.fzf_e] && [.ins.top3.fzf_e get] ne {}} {
+      .ins.top3.fzf_e delete 0 end
+      fuzzy_chooser_inline {}
+    }
     file_chooser_search current
   }
   bind .ins.center.leftdir.l <<ListboxSelect>> {
@@ -6135,6 +6218,8 @@ proc file_chooser {} {
   pack .ins.top.editpaths -side left
   pack .ins.top3.ext_l -side left
   pack .ins.top3.ext_e -side left
+  pack .ins.top3.fzf_l -side left
+  pack .ins.top3.fzf_e -side left
   if { [info exists file_chooser(geometry)]} {
     wm geometry .ins "${file_chooser(geometry)}"
   } elseif {[file exists $USER_CONF_DIR/file_chooser_geometry]} {
@@ -6179,6 +6264,9 @@ proc file_chooser {} {
       "set file_chooser(sp1) $file_chooser(sp1)\n" \
     ] $USER_CONF_DIR/file_chooser_geometry
   }
+  set file_chooser(files) {}
+  set file_chooser(fullpathlist) {}
+  set file_chooser(nitems) 0
   file_chooser_dirlist
   file_chooser_filelist
   set file_chooser(old_dirs) $file_chooser(dirs)

--- a/src/xschem.tcl
+++ b/src/xschem.tcl
@@ -6042,6 +6042,9 @@ proc file_chooser {} {
   bind .ins.top3.fzf_e <KeyRelease> {
     fuzzy_chooser_inline [.ins.top3.fzf_e get]
   }
+  bind .ins.top3.fzf_e <FocusIn> {
+    fuzzy_chooser_inline [.ins.top3.fzf_e get]
+  }
 
   button .ins.top4.select_current -takefocus 0 -text {Select current} -command {
     set file_chooser(regex) {}

--- a/src/xschem.tcl
+++ b/src/xschem.tcl
@@ -4689,6 +4689,92 @@ proc load_additional_files {} {
 # confirm_overwrt: ask before overwriting an existing file
 # initialf: fill the file entry box with this name (used when saving)
 #
+proc fuzzy_subseq_score {q s} {
+  set q [string tolower $q]
+  set s [string tolower $s]
+  set n [string length $q]
+  set m [string length $s]
+  if {$n == 0} { return 0 }
+  if {$n > $m} { return -1 }
+  set qi 0
+  set last -2
+  set score 0
+  for {set i 0} {$i < $m && $qi < $n} {incr i} {
+    if {[string index $q $qi] eq [string index $s $i]} {
+      incr score 1
+      if {$i == $last + 1} { incr score 3 }
+      if {$i == 0} {
+        incr score 6
+      } else {
+        if {[regexp {[/_\-. ]} [string index $s [expr {$i-1}]]]} { incr score 4 }
+      }
+      set last $i
+      incr qi
+    }
+  }
+  if {$qi < $n} { return -1 }
+  return [expr {$score * 100 - $last}]
+}
+
+proc fuzzy_match_glob {pat name} {
+  if {[regexp {^(.*)\{([^{}]+)\}(.*)$} $pat -> pre alts post]} {
+    foreach alt [split $alts ","] {
+      if {[string match "${pre}${alt}${post}" $name]} { return 1 }
+    }
+    return 0
+  }
+  return [string match $pat $name]
+}
+
+proc fuzzy_walk {dir maxdepth} {
+  set out {}
+  if {$maxdepth <= 0} { return $out }
+  if {[catch {glob -nocomplain -directory $dir -tails *} entries]} { return $out }
+  foreach e $entries {
+    if {[string index $e 0] eq "."} { continue }
+    set full [file join $dir $e]
+    if {[file isdirectory $full]} {
+      foreach sub [fuzzy_walk $full [expr {$maxdepth - 1}]] {
+        lappend out [file join $e $sub]
+      }
+    } else {
+      lappend out $e
+    }
+  }
+  return $out
+}
+
+proc fuzzy_filter_files2 {q} {
+  global file_dialog_files2 file_dialog_dir1 file_dialog_ext
+  if {$q eq {}} {
+    setglob $file_dialog_dir1
+    return
+  }
+  set all [fuzzy_walk $file_dialog_dir1 6]
+  set ext_pat $file_dialog_ext
+  if {$ext_pat ne {} && $ext_pat ne {*}} {
+    set filt {}
+    foreach f $all {
+      if {[fuzzy_match_glob $ext_pat [file tail $f]]} { lappend filt $f }
+    }
+    set all $filt
+  }
+  set scored {}
+  foreach name $all {
+    set sc [fuzzy_subseq_score $q $name]
+    if {$sc >= 0} { lappend scored [list $sc $name] }
+  }
+  set sorted [lsort -decreasing -integer -index 0 $scored]
+  set out {}
+  set n 0
+  foreach pair $sorted {
+    if {$n >= 500} break
+    lappend out [lindex $pair 1]
+    incr n
+  }
+  set file_dialog_files2 $out
+}
+
 proc load_file_dialog {{msg {}} {ext {}} {global_initdir {INITIALINSTDIR}}
      {loadfile {1}} {confirm_overwrt {1}} {initialf {}}} {
   global file_dialog_index1 file_dialog_files2 file_dialog_files1 file_dialog_retval file_dialog_dir1 pathlist OS
@@ -4853,6 +4939,16 @@ proc load_file_dialog {{msg {}} {ext {}} {global_initdir {INITIALINSTDIR}}
     set file_dialog_retval {   }
   }
 
+  label .load.buttons_bot.fzflab -text { Fuzzy:}
+  entry .load.buttons_bot.fzf -width 18 -highlightcolor red -highlightthickness 2 \
+    -highlightbackground [option get . background {}]
+  entry_replace_selection .load.buttons_bot.fzf
+  bind .load.buttons_bot.fzf <KeyRelease> {
+    fuzzy_filter_files2 [.load.buttons_bot.fzf get]
+    file_dialog_set_colors2
+    set file_dialog_retval {   }
+  }
+
   button .load.buttons.up -width 5 -text Up -command {load_file_dialog_up  $file_dialog_dir1} -takefocus 0
   label .load.buttons.mkdirlab -text { New dir: }
   entry .load.buttons.newdir -width 16 -takefocus 0
@@ -4887,6 +4983,8 @@ proc load_file_dialog {{msg {}} {ext {}} {global_initdir {INITIALINSTDIR}}
   pack .load.buttons.rmdir .load.buttons.mkdir -side right
   pack .load.buttons_bot.srclab -side left
   pack .load.buttons_bot.src -side left
+  pack .load.buttons_bot.fzflab -side left
+  pack .load.buttons_bot.fzf -side left
   pack .load.buttons_bot.label -side left
   pack .load.buttons_bot.entry -side left -fill x -expand true
 

--- a/src/xschem.tcl
+++ b/src/xschem.tcl
@@ -4691,6 +4691,7 @@ proc load_additional_files {} {
 #
 proc fuzzy_subseq_score {q s} {
   set q [string tolower $q]
+  regsub -all { } $q {} q
   set s [string tolower $s]
   set n [string length $q]
   set m [string length $s]

--- a/src/xschem.tcl
+++ b/src/xschem.tcl
@@ -4949,6 +4949,11 @@ proc load_file_dialog {{msg {}} {ext {}} {global_initdir {INITIALINSTDIR}}
     file_dialog_set_colors2
     set file_dialog_retval {   }
   }
+  bind .load.buttons_bot.fzf <FocusIn> {
+    fuzzy_filter_files2 [.load.buttons_bot.fzf get]
+    file_dialog_set_colors2
+    set file_dialog_retval {   }
+  }
 
   button .load.buttons.up -width 5 -text Up -command {load_file_dialog_up  $file_dialog_dir1} -takefocus 0
   label .load.buttons.mkdirlab -text { New dir: }


### PR DESCRIPTION
## Summary

- Adds a `Fuzzy:` entry next to the existing `Search:` entry in the original file-load dialog (`load_file_dialog`).
- Adds a `Fuzzy:` entry next to the existing `Pattern:` / `Extension:` entries in the new file browser (`file_chooser` / `.ins`), which is enabled via the `new_file_browser` xschemrc flag.
- Pure-Tcl, no new dependencies, no C-level changes.
- Does **not** alter existing behavior when the Fuzzy entry is empty — the regex/glob path remains the default.

## Motivation

The existing `Search:` entry uses Tcl's `glob` style and only filters the current directory; the new file browser's `Pattern:` is a regex but requires precise authoring and still operates with rigid matching. Both make it slow to land on a specific cell in a deep library tree when you only remember a few characters of the name.

Editor / launcher tools (Neovim's [Telescope](https://github.com/nvim-telescope/telescope.nvim), [fzf](https://github.com/junegunn/fzf), VS Code's command palette) have made *subsequence-with-ranking* the expected interaction for this kind of "I half-remember the name" lookup. This PR brings that experience to xschem's two file pickers without disturbing the existing knobs.

## What's new

- **Fuzzy entry in the original file-load dialog** (`load_file_dialog`). Recursively walks the selected library and replaces the file listbox with subsequence-scored hits. Selection flow unchanged.

- **Fuzzy entry in the new `file_chooser` (`.ins`) dialog**, alongside the existing `Pattern:`/`Extension:` row. Filters in place — left pane reduces to only dirs with hits, middle pane shows full paths ranked by score.

  *Worth a closer look:* this is the first call site that rewrites `file_chooser(dirs)` / `dirtails` *after* dialog construction. Tk listbox per-index `-foreground` config persists across `-listvariable` updates, so the existing `file_chooser_dirlist` coloring logic had to be reapplied here to keep blue (library root) vs. black (subdir) aligned with content. Any future call site that rewrites these vars in place needs the same recoloring.

- **Spaces in fuzzy queries are stripped**, so `power amp` matches `power_amp.sym`, `single to diff` matches `single_to_diff.sch`. Applies to both fuzzy entries.

- **Clicking or tabbing into a Fuzzy entry re-applies its current query** in both dialogs (FocusIn binding alongside the keystroke binding).

## How the matching works

The scoring is intentionally tiny — a single Tcl proc, no precomputed indexes. It is loosely modeled on the algorithm fzf uses for "extended" matches (which is in turn what `telescope-fzf-native` ports to LuaJIT FFI), but trimmed:

```
proc fuzzy_subseq_score {q s} {
  set q [string tolower $q]
  regsub -all { } $q {} q
  set s [string tolower $s]
  ...
  for each i in s, advancing qi when chars equal:
    +1 base hit
    +3 if this hit is consecutive with the previous hit
    +6 if at start of haystack (otherwise)
    +4 if previous char in haystack is a word boundary [/_-. ]
  if qi did not consume all of q: return -1 (no match)
  return score * 100 - last_match_index    ; tie-break: earlier finishes win
}
```

Why this and not a full fzf port?

- **Subsequence matching** (every query char must appear in order, contiguity not required) is the core property users learn from fzf/Telescope and the only one that matters for "I remember a few chars."
- **Word-boundary bonus** is what makes basename starts and dir-component starts win over middle-of-string letter coincidences. The boundary set `[/_-. ]` is tuned for path-like haystacks.
- **No precomputation** keeps it ~50 LOC of Tcl and avoids a perceptible "open dialog" delay even on libraries with thousands of cells. The cap at top-500 results similarly keeps the listbox snappy.
- **No bonuses for camel-case humps** — xschem cells are overwhelmingly snake_case, so it'd be dead code.

The actual fzf scoring is more elaborate (it tracks per-character bonuses, applies a Smith-Waterman-style DP for the optimal alignment, and gives different weights to camel-case humps and consecutive-after-boundary patterns). If a future rewrite wants to vendor [fzf.c](https://github.com/junegunn/fzf/blob/master/src/algo/algo.go) (the Go reference impl) or the C port from `telescope-fzf-native`, the call site is one proc — `fuzzy_subseq_score` — and could be swapped without touching the dialog code.

## Demo

https://github.com/user-attachments/assets/33a93431-d961-4bc1-84bc-ff2d710a70f7

## Testing

- Manually exercised against a multi-library design tree (~3500 files, depth 4) inside the IIC-OSIC-TOOLS docker. Both dialogs open, Fuzzy filters and reorders correctly, selection / open / preview all use the existing handlers unchanged.
- `tclsh` unit tests for `fuzzy_subseq_score` and `fuzzy_match_glob` (subsequence ordering, brace expansion, space-stripping, no-match cases) — a small `tests/fuzzy_unit.tcl` could be added if desired.
- xschem's existing regression suite (`tests/run_regression.tcl`) is untouched and still passes — it doesn't exercise either dialog, so nothing in the new code paths can affect it.

## Backward compatibility

- All new code is additive. Empty Fuzzy entry → identical behavior to before this PR.
- No changes to xschemrc variables, no new ones introduced.
- No changes to the C side.
- No changes to how files are actually loaded / opened — selection still flows through `file_dialog_getresult` and `file_chooser_symbol_or_schematic`.
